### PR TITLE
update: blame file for continuous test to include graffiti info for included transaction block

### DIFF
--- a/continuous/collector.go
+++ b/continuous/collector.go
@@ -280,7 +280,7 @@ func collectSubmitIncomingTx(startBlock uint64, endBlock uint64, cache *BlockCac
 					}
 
 					success := Success{
-						trigger:         tx.Value().Int64(),
+						trigger:         tx.Value().Int64(), // this is the block number we submitted for, tx value holds it
 						included:        blockNumber,
 						validatorIndex:  validatorIndex,
 						graffiti:        graffiti,


### PR DESCRIPTION
closes https://github.com/shutter-network/shutter-tests/issues/24